### PR TITLE
Paginate Fix

### DIFF
--- a/Server/src/controllers/articles/getArticlesController.ts
+++ b/Server/src/controllers/articles/getArticlesController.ts
@@ -9,8 +9,7 @@ import { paginado } from "../../utils/paginado";
 const getArticlesController = async(offset:number, limit:number, order:any ) => {
     
     const count = await articleRepository.count();
-    
-    
+        
     const allArticles = await articleRepository.find({
         order:{
             price: order
@@ -21,7 +20,7 @@ const getArticlesController = async(offset:number, limit:number, order:any ) => 
     
     const pag = paginado(offset,limit,count)
 
-    if(allArticles.length === 0) throw new Error ("No hay articulos para mostar");
+    if(!allArticles.length) throw new Error ("No hay articulos para mostar");
     return {...pag,allArticles};
 }
 

--- a/Server/src/routes/articles/getArticles.ts
+++ b/Server/src/routes/articles/getArticles.ts
@@ -14,11 +14,12 @@ const getArticles = async (req:Request, res:Response) => {
         
         let offset = req.query.offset as string
         let limit = req.query.limit as string
-        
+       
         if(!offset || offset < '0') offset='0'
         if(!limit || limit === '0')  limit= '12'
 
         if (nameFilter ||  genderFilter || typeFilter || colorFilter) {
+            // const articleByName = await getArticlesByNameController(nameFilter, genderFilter, typeFilter, colorFilter,+offset,+limit, priceOrder);
             const articleByName = await getArticlesByNameController(nameFilter, genderFilter, typeFilter, colorFilter,+offset,+limit, priceOrder);
             return res.status(200).json(articleByName)
         }

--- a/Server/src/utils/paginado.ts
+++ b/Server/src/utils/paginado.ts
@@ -1,12 +1,16 @@
+const { PORT } = process.env
+
 export const paginado = (offset:number, limit:number, count: number) =>{
     let next = '';
     let prev = '';
 
     if(offset + limit >= count) next = 'null'
-    else next = `http://localhost:3002/articles?offset=${offset + limit}&limit=${limit}`
+    if(offset === 0) next = `http://localhost:${PORT}/articles?offset=${limit}&limit=${limit + 12}`
+    else next = `http://localhost:${PORT}/articles?offset=${limit}&limit=${limit + 12}`
 
     if(offset <= 0) prev = 'null'
-    else prev = `http://localhost:3002/articles?offset=${+Math.sign(offset - limit) ?  (offset - limit <= 0 ? '0' : offset - limit): '0' }&limit=${limit}`
+    // else prev = `http://localhost:${PORT}/articles?offset=${+Math.sign(offset - limit) ?  (offset - limit <= 0 ? '0' : offset): '0' }&limit=${limit}`
+    else prev = `http://localhost:${PORT}/articles?offset=${limit - 24}&limit=${limit - 12}`
 
     let pag = {
         count,


### PR DESCRIPTION
*Se pone una variable en el puerto de la paginación (para localhost)
*Se modifica la función para que no aumente offset y limit exponencialmente
*El aumento de páginas queda seteado de 12 en 12 y tb disminuye de 12 en 12
*La ruta funciona con querys autogeneradas, no espera que se le pasen valores para paginar